### PR TITLE
Add ADW vs ADL pie chart, update player dialog layout, and refine pla…

### DIFF
--- a/app-duels-mapping/app/PlayersPageCore.js
+++ b/app-duels-mapping/app/PlayersPageCore.js
@@ -348,7 +348,10 @@ export default function PlayersPage() {
 
   // CUSTOM STYLED PAGINATION
   const handlePageChange = (event, value) => setPage(value);
-  const handlePageSizeChange = (event) => setPageSize(event.target.value);
+  const handlePageSizeChange = (event) => {
+    setPageSize(event.target.value);
+    setPage(1);
+  };
 
   const totalPages = Math.ceil(filteredRows.length / pageSize);
   const paginatedRows = filteredRows.slice(
@@ -767,7 +770,7 @@ export default function PlayersPage() {
                   variant="body2"
                   fontFamily="'Bebas Neue', sans-serif"
                 >
-                  Players by Page
+                  Players per Page
                 </Typography>
 
                 <Select
@@ -864,7 +867,7 @@ export default function PlayersPage() {
                     },
                   }}
                 >
-                  {[5, 10, 25, 50].map((size) => (
+                  {[5, 10, 25, 100].map((size) => (
                     <MenuItem
                       key={size}
                       value={size}

--- a/app-duels-mapping/app/components/charts/PlayerDuelsPieChart.js
+++ b/app-duels-mapping/app/components/charts/PlayerDuelsPieChart.js
@@ -1,0 +1,106 @@
+"use client";
+
+import { useMemo } from "react";
+import { Box, useTheme, Typography } from "@mui/material";
+import { Chart as ChartJS, ArcElement, Tooltip, Legend } from "chart.js";
+import { Pie } from "react-chartjs-2";
+import { baseChartTooltipOptions } from "./styles/chartTooltipOptions";
+
+ChartJS.register(ArcElement, Tooltip, Legend);
+
+function createDiagonalPattern(color) {
+  const size = 8;
+  const canvas = document.createElement("canvas");
+  canvas.width = size;
+  canvas.height = size;
+  const ctx = canvas.getContext("2d");
+  ctx.strokeStyle = color;
+  ctx.lineWidth = 1.5;
+  ctx.beginPath();
+  ctx.moveTo(0, size);
+  ctx.lineTo(size, 0);
+  ctx.stroke();
+  return ctx.createPattern(canvas, "repeat");
+}
+
+export default function PlayerDuelsPieChart({ player }) {
+  const theme = useTheme();
+  const isDark = theme.palette.mode === "dark";
+
+  // ADL is slice 0 (sweeps right), ADW is slice 1 (lands on left) with rotation Math.PI/2
+  const labels = ["ADL", "ADW"];
+  const data = [player.aerial_duels_lost ?? 0, player.aerial_duels_won ?? 0];
+
+  const adwColor = isDark
+    ? theme.palette.common.limegreen
+    : theme.palette.common.blue;
+  const adwBgColor = isDark
+    ? "rgba(183, 240, 142, 0.4)"
+    : "rgba(59, 91, 132, 0.4)";
+
+  const adlColor = isDark ? theme.palette.common.blue : "#888888";
+
+  const adlBgColor = useMemo(() => {
+    if (typeof window === "undefined") return "transparent";
+    return isDark ? "rgba(59, 91, 132, 0.4)" : createDiagonalPattern("#888888");
+  }, [isDark]);
+
+  return (
+    <Box sx={{ display: "flex", flexDirection: "column", height: "100%" }}>
+      <Box
+        display="flex"
+        justifyContent="space-between"
+        alignItems="center"
+        mb={0}
+      >
+        <Typography
+          variant="subtitle1"
+          component={"div"}
+          sx={{ fontFamily: "'Bebas Neue', sans-serif", fontSize: "1.25rem" }}
+        >
+          Aerial Duels Won vs Lost
+        </Typography>
+      </Box>
+
+      <Box sx={{ flexGrow: 1, position: "relative" }}>
+      <Pie
+        data={{
+          labels,
+          datasets: [
+            {
+              label: player.player_name,
+              data,
+              backgroundColor: [adlBgColor, adwBgColor],
+              borderColor: [adlColor, adwColor],
+              borderWidth: 2,
+            },
+          ],
+        }}
+        options={{
+          responsive: true,
+          maintainAspectRatio: false,
+          rotation: Math.PI / 2,
+          plugins: {
+            legend: {
+              display: true,
+              position: "bottom",
+              reverse: true,
+              labels: {
+                color: isDark
+                  ? theme.palette.common.white
+                  : theme.palette.common.black,
+                font: {
+                  family: "'Nunito Sans', sans-serif",
+                  size: 12,
+                },
+                padding: 16,
+              },
+            },
+            tooltip: baseChartTooltipOptions(theme),
+          },
+        }}
+      />
+      </Box>
+    </Box>
+  );
+}

--- a/app-duels-mapping/app/components/charts/PlayerMetricsLineChart.js
+++ b/app-duels-mapping/app/components/charts/PlayerMetricsLineChart.js
@@ -51,7 +51,7 @@ export default function PlayerMetricsLineChart({
   const labels = ["ADW", "ADL", "TKW", "INT", "RECOV"];
 
   const dataValues = labels.map((label) => metrics[label] ?? 0);
-  const averageValues = labels.map((label) => averages[label] ?? 0);
+  const averageValues = labels.map((label) => Math.round(averages[label] ?? 0));
   const maxValues = labels.map((label) => maxes[label] ?? 0);
 
   // Colors

--- a/app-duels-mapping/app/components/players/PlayerDetailDialog.js
+++ b/app-duels-mapping/app/components/players/PlayerDetailDialog.js
@@ -14,7 +14,7 @@ import {
 import { getInitials } from "@/utils/getInitials";
 import SchmetzerScoreBar from "../charts/SchmetzerScoreBar";
 import PlayerMetricsLineChart from "../charts/PlayerMetricsLineChart";
-import PlayerPolarChart from "../charts/PlayerPolarChart";
+import PlayerDuelsPieChart from "../charts/PlayerDuelsPieChart";
 import SchmetzerTrendChart from "../charts/SchmetzerTrendChart";
 import IconButton from "@mui/material/IconButton";
 import CloseIcon from "@mui/icons-material/Close";
@@ -199,20 +199,6 @@ export default function PlayerDetailDialog({
             <Box
               p={4}
               borderRadius={0}
-              height={"100%"}
-              sx={{
-                backgroundColor:
-                  theme.palette.mode === "dark" ? "#303034" : "#FAFAFA",
-              }}
-            >
-              <PlayerPolarChart player={player} />
-            </Box>
-          </Grid>
-
-          <Grid item size={{ xs: 12, sm: 6 }}>
-            <Box
-              p={4}
-              borderRadius={0}
               height="100%"
               width="100%"
               sx={{
@@ -231,6 +217,20 @@ export default function PlayerDetailDialog({
                 averages={seasonAverages}
                 maxes={seasonMaxes}
               />
+            </Box>
+          </Grid>
+
+          <Grid item size={{ xs: 12, sm: 6 }}>
+            <Box
+              p={4}
+              borderRadius={0}
+              height={"100%"}
+              sx={{
+                backgroundColor:
+                  theme.palette.mode === "dark" ? "#303034" : "#FAFAFA",
+              }}
+            >
+              <PlayerDuelsPieChart player={player} />
             </Box>
           </Grid>
 


### PR DESCRIPTION
…yers table

- Add PlayerDuelsPieChart with theme-aware colors (blue/green for ADW, diagonal pattern for ADL)
- Replace PolarChart with pie chart in PlayerDetailDialog, reorder charts (line before pie)
- Round averages to nearest integer in PlayerMetricsLineChart
- Update PlayersPageCore: options 5/10/25/100, label "Players per Page"